### PR TITLE
Only destroy/re-add bot when necessary

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,6 +149,7 @@ Bot.prototype.registerBot = function() {
                function(error, response, body) {
                  if (!error) {
                    var parsedBody = JSON.parse(body).response.bot;
+                   this.emit('botRegistered', this); 
                    callback(null, parsedBody.bot_id);
                  } else {
                    callback(error);
@@ -158,7 +159,7 @@ Bot.prototype.registerBot = function() {
     }.bind(this)
   ], function (err, bot_id) {
     this.botId = bot_id;
-    this.emit('botRegistered', this);
+    this.emit('botReady', this);
   }.bind(this));
 };
 


### PR DESCRIPTION
This changes the behavior of the bot to only detroy/readd the bot when something has changed with the config (i.e. callback url or avatar url).  This prevents unnecessary noise in a groupme when a bot regularly connects/disconnects (which happens frequently with heroku).

There is a potential breaking change in the second commit.  I modified it to only emit botRegistered when the bot is actually registered (either for the first time, or when it needs to be recreated).  I added a new emit event called botReady that is called regardless of whether the bot needed to be recreated.